### PR TITLE
Only require explicitly C++20 on Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,11 @@ reloc_cpp_generate(${PROJECT_NAME}
                    GENERATED_FUNCTION MeshcatCpp::getInstallPrefix)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
+if(MSVC)
+  target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
+else()
+  target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
   stduuid


### PR DESCRIPTION
While technically speaking designated constructors are a C++20 only feature, apparently just requiring C++17 is sufficient on Linux/macOS, while we need to require C++20 on MSVC. As some downstream users prefer that we do not explicitly force C++20 (see https://github.com/ami-iit/meshcat-cpp/issues/7) and for us I guess it does not change much, I think we can only require C++20 on Windows.